### PR TITLE
Translate .travis.yml to cloudbuild.yaml with Oracle support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8-jre
+ADD target/vertx-template-1.0-SNAPSHOT.jar /vertx-template-1.0-SNAPSHOT.jar
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/vertx-template-1.0-SNAPSHOT.jar"]
+

--- a/check_oracle_table.sh
+++ b/check_oracle_table.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+VAR="ERROR: ORA-"
+while [[ $VAR =~ "ERROR: ORA-" ]]
+do
+  echo "checking existence of app_message"
+  VAR=`/u01/app/oracle/product/12.2.0/dbhome_1/bin/sqlplus -S sys/Oradoc_db1@dbserver.workspace_default:1521/ORCLCDB.localdomain as sysdba   << EOF
+describe app_message
+EOF`
+  sleep 10
+done
+echo "app_message table is created"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,39 @@
+# cloudbuild.yaml for building vertx-template with Oracle DB in GCB
+
+
+# Credentials of SourceClear and Docker Store are encrypted using Google Cloud KMS
+# Docker Store secret is used for Oracle DB
+# See below link for more information on using Google Cloud KMS:
+# https://cloud.google.com/container-builder/docs/securing-builds/use-encrypted-secrets-credentials#encrypting_an_environment_variable_using_the_cryptokey
+
+secrets:
+- kmsKeyName: projects/<GCP-PROJECT-ID>/locations/global/keyRings/<GCP-KMS-KEYRING-NAME>/cryptoKeys/<GCP-KMS-KEY-NAME>
+  secretEnv:
+    SRCCLR_API_TOKEN: <ENCRYPTED-SOURCECLEAR-AGENT-API-TOKEN>
+    DOCKER_USERNAME: <ENCRYPTED-DOCKER-USERNAME>
+    DOCKER_PASSWORD: <ENCRYPTED-DOCKER-PASSWORD>
+
+# Build Steps:
+# 1. ojdbc7.jar is copied from Google Cloud Storage bucket to GCB workspace for
+#    using local maven repository to get the ojdbc7.jar dependency
+# 2. This build step uses docker-compose custom image based on gcr.io/cloud-builders/mvn and invokes a shell script "docker-compose.sh" which launches dbserver and appserver services using docker-compose. The dbserver service is a Oracle container and appserver service runs mvn commands.
+
+# 3. Building GCR image with JAR artifacts.
+
+# Note: Edited sample.properties for Oracle and enabled ojdbc7 dependency in pom.xml
+# Note: docker-compose.yml is used by docker-compose in "docker-compose.sh" in Build Step 2
+# Note: "check_oracle_table.sh" is used in "docker-compose.sh"  to verify creation of tables in Oracle DB.
+# Note: Dockerfile is used in step 3 to build GCR image with JAR artifacts
+
+steps:
+- name: gcr.io/cloud-builders/gsutil
+  args: ['cp', 'gs://<GCS-BUCKET-HOSTING-OJDBC7.JAR>/ojdbc7.jar', 'ojdbc7.jar']
+- name: 'gcr.io/$PROJECT_ID/docker-compose:latest'
+  entrypoint: 'bash'
+  args: ['-c', './docker-compose.sh']
+  secretEnv: ['SRCCLR_API_TOKEN','DOCKER_USERNAME','DOCKER_PASSWORD']
+- name: 'gcr.io/cloud-builders/docker'
+  args: ["build", "-t", "gcr.io/$PROJECT_ID/vertx-template-oracle:latest", "."]
+
+images:
+  - 'gcr.io/$PROJECT_ID/vertx-template-oracle:latest'

--- a/docker-compose.sh
+++ b/docker-compose.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Oracle image pull need authentication to Docker Store
+echo "Login to Docker Store : docker login"
+docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
+
+# docker-compose.yml is used by docker-compose
+# Start Oracle database service
+echo "Starting Oracle DB service: docker-compose up -d dbserver"
+docker-compose up -d dbserver
+
+echo "Checking Oracle database health ... "
+
+DB_HEALTH=""
+while [ "${DB_HEALTH}" != "\"healthy\"" ]
+do
+ DB_HEALTH="$(docker inspect --format='{{json .State.Health.Status}}' dbserver)"
+ sleep 20
+ echo $DB_HEALTH
+done
+
+# Start application build service:
+# ojdbc7.jar dependency will be installed in local maven repo.
+# App Source code will be built and the application will run against the Oracle Database
+
+echo "Starting application build service: docker-compose up appserver"
+docker-compose up appserver
+
+# Checking existence of table app_server in Oracle Database created by the application
+sudo docker exec dbserver /workspace/check_oracle_table.sh
+
+# Cleaning the docker-compose resources
+docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+
+services:
+ dbserver:
+   image: store/oracle/database-enterprise:12.2.0.1-slim
+   container_name: dbserver
+   volumes:
+     - /workspace:/workspace
+   ports:
+     - "1521:1521"
+ appserver:
+   image: gcr.io/cloud-builders/mvn
+   container_name: appserver
+   environment:
+   - SRCCLR_API_TOKEN=$SRCCLR_API_TOKEN
+   volumes:
+     - /workspace:/workspace
+   entrypoint: |
+     bash -c "
+     apt-get update; apt-get install curl -y; \
+     cd /workspace; mvn install:install-file -Dfile=./ojdbc7.jar \
+     -DgroupId=com.oracle.jdbc -DartifactId=ojdbc7 -Dversion=12.1.0.2 \
+     -Dpackaging=jar; mvn -DskipTests clean package; \
+     curl -sSL https://download.sourceclear.com/ci.sh | sh; \
+     nohup java -Ddatabase.url=jdbc:oracle:thin:@dbserver.workspace_default:1521/ORCLCDB.localdomain \
+     -Djava.security.egd=file:/dev/./urandom -jar ./target/vertx-*-SNAPSHOT.jar create-database run 2>&1 &"
+   depends_on:
+     - dbserver

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,12 @@
       <artifactId>vertx-base</artifactId>
       <version>1.1-SNAPSHOT</version>
     </dependency>
+    <dependency>
+      <groupId>com.oracle.jdbc</groupId>
+      <artifactId>ojdbc7</artifactId>
+      <version>12.1.0.2</version>
+      <scope>runtime</scope>
+    </dependency>
     <!-- There are three profiles ("hsql" the default, "postgres", and "oracle")
          that are normally used to control which database drivers get embedded
          in our executable jar. If you want to always include a particular set,

--- a/sample.properties
+++ b/sample.properties
@@ -1,11 +1,15 @@
 # By default we will use a local, embedded Java database for
 # convenience during development
-database.url=jdbc:hsqldb:file:.hsql/db;shutdown=true
-database.user=SA
-database.password=
+#database.url=jdbc:hsqldb:file:.hsql/db;shutdown=true
+#database.user=SA
+#database.password=
+database.driver=oracle.jdbc.driver.OracleDriver
+database.user=sys as sysdba
+database.password=Oradoc_db1
 
 # Declare any outbound network connections to be allowed by security manager
 #connect.outbound=some-database:1521,my-email-server:1234
+connect.outbound=dbserver.workspace_default:1521
 
 # Enable development features to make life easier, such as
 # fake authentication


### PR DESCRIPTION
We have created two branches for translation of .travis.yml to cloudbuild.yaml.

This branch pull request has configurations to build application with Oracle DB.

Example build log is attached to this PR description.

[oracle-build-log.txt](https://github.com/susom/vertx-template/files/2054527/oracle-build-log.txt)
