### PR TITLE
Translate .travis.yml to cloudbuild.yaml with postgres and OracleDB s…

### DIFF
--- a/Dockerfile_oracledb
+++ b/Dockerfile_oracledb
@@ -1,0 +1,3 @@
+FROM openjdk:8-jre
+ADD target/vertx-template-1.0-SNAPSHOT.jar /vertx-template-1.0-SNAPSHOT.jar
+ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom", "-jar", "/vertx-template-1.0-SNAPSHOT.jar"]

--- a/Dockerfile_postgres
+++ b/Dockerfile_postgres
@@ -1,0 +1,3 @@
+FROM openjdk:8-jre
+ADD target/vertx-template-1.0-SNAPSHOT.jar /vertx-template-1.0-SNAPSHOT.jar
+ENTRYPOINT ["java", "-jar", "/vertx-template-1.0-SNAPSHOT.jar"]

--- a/check_oracledb_health.sh
+++ b/check_oracledb_health.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+num_retry=0
+until [[ "$num_retry" -gt "$DB_HLTH_CHK_MAX_RETRY" ]]
+do
+  echo "retry-$num_retry to check health of Oracle DB"
+  num_retry=$((num_retry+1))
+  DB_HEALTH="$(docker inspect --format='{{json .State.Health.Status}}' "$ORACLEDB_SERVER")"
+  echo "Oracle DB is $DB_HEALTH"
+  if [[ "${DB_HEALTH}" == "\"healthy\"" ]]; then
+    exit 0
+  fi
+  sleep "$DB_HLTH_CHK_SLEEP"
+done
+
+exit 1

--- a/check_oracledb_table.sh
+++ b/check_oracledb_table.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+SQLPATH="/u01/app/oracle/product/12.2.0/dbhome_1/bin/sqlplus"
+LOGON="sys/Oradoc_db1@$ORACLEDB_SERVER:1521/ORCLCDB.localdomain as sysdba"
+
+num_retry=0
+until [[ "$num_retry" -gt "$DB_TBL_CHK_MAX_RETRY" ]]
+do
+  echo "retry-$num_retry to check existence of table app_message in Oracle DB"
+  num_retry=$((num_retry+1))
+  RESP=$("$SQLPATH" -S "$LOGON" << EOF
+describe app_message
+EOF
+)
+  echo "app_message table creation status is: $RESP"
+  if [[ "$RESP" != *"ERROR:"* ]]; then
+    exit 0
+  fi
+  sleep "$DB_TBL_CHK_SLEEP"
+done
+
+exit 1

--- a/check_postgres_health.sh
+++ b/check_postgres_health.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+num_retry=0
+until [[ "$num_retry" -gt "$DB_HLTH_CHK_MAX_RETRY" ]]
+do
+  echo "retry-$num_retry to check health of Postgres DB"
+  num_retry=$((num_retry+1))
+  RESP=$(PGPASSWORD=$POSTGRES_PASSWORD psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h "$POSTGRES_SERVER" -c '\dt' > /dev/null 2>&1; echo $?)
+  if [[ "$RESP" == 0 ]]; then
+    echo "Postgres DB is healthy"
+    exit 0
+  fi
+  sleep "$DB_HLTH_CHK_SLEEP"
+done
+
+echo "Postgres DB is not healthy"
+exit 1

--- a/check_postgres_table.sh
+++ b/check_postgres_table.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+num_retry=0
+until [[ "$num_retry" -gt "$DB_TBL_CHK_MAX_RETRY" ]]
+do
+  echo "retry-$num_retry to check existence of table app_message in Postgres DB"
+  num_retry=$((num_retry+1))
+  RESP=$(PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -h "$POSTGRES_SERVER" -c '\d app_message' > /dev/null 2>&1; echo $?)
+  if [[ "$RESP" == 0 ]]; then
+    echo "app_message table is created"
+    exit 0
+  fi
+  sleep "$DB_TBL_CHK_SLEEP"
+done
+
+echo "app_message table is not created"
+exit 1

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,12 +55,6 @@ steps:
          -v /workspace:/workspace $$ORACLEDB_IMAGE"]
   env: ['ORACLEDB_IMAGE=store/oracle/database-enterprise:12.2.0.1-slim', 'ORACLEDB_SERVER=oracle-dbserver',
         'ORACLEDB_NET=stanford-oracledb']
- 
- # Checking the health of Oracle DB server
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: ['-c', './check_oracledb_health.sh']
-  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'ORACLEDB_SERVER=oracle-dbserver']
 
 # Building application jar using APP build server
 - name: 'gcr.io/cloud-builders/docker'
@@ -74,6 +68,12 @@ steps:
   env: ['APP_BUILD_SERVER=oracledb-app-build-server', 'ORACLEDB_NET=stanford-oracledb',
         'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
   secretEnv: ['SRCCLR_API_TOKEN']
+
+# Checking the health of Oracle DB server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', './check_oracledb_health.sh']
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'ORACLEDB_SERVER=oracle-dbserver']
 
 # Testing application jar using APP test server
 - name: 'gcr.io/cloud-builders/docker'
@@ -120,13 +120,6 @@ steps:
   env: ['POSTGRES_IMAGE=postgres:9.3', 'POSTGRES_USER=test', 'POSTGRES_PASSWORD=test', 'POSTGRES_DB=test',
         'POSTGRES_SERVER=postgres-dbserver', 'POSTGRES_NET=stanford-postgres']
 
-# Checking the health of Postgres server
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_HLTH_CHK_MAX_RETRY \
-         -e DB_HLTH_CHK_SLEEP $$POSTGRES_SERVER /workspace/check_postgres_health.sh"]
-  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'POSTGRES_SERVER=postgres-dbserver']
-
 # Building application jar using APP build server
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
@@ -137,6 +130,13 @@ steps:
   env: ['APP_BUILD_SERVER=postgres-app-build-server', 'POSTGRES_NET=stanford-postgres',
         'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
   secretEnv: ['SRCCLR_API_TOKEN']
+
+# Checking the health of Postgres server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_HLTH_CHK_MAX_RETRY \
+         -e DB_HLTH_CHK_SLEEP $$POSTGRES_SERVER /workspace/check_postgres_health.sh"]
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'POSTGRES_SERVER=postgres-dbserver']
 
 # Testing application jar using APP test server
 - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,166 @@
+#
+# cloudbuild.yaml for building and testing vertx-template with Oracle DB and Postgres in GCB
+#
+
+# Google Cloud KMS KeyRing and CryptoKey are created for encrypting credentials of SourceClear and Docker Store
+# Container Builder service account is granted access to the CryptoKey.
+# Run the following command in shell or terminal window to encrpt SourceClear and Docker Store credentials
+# MY_SECRET=<enter-your-credential>
+# echo -n $MY_SECRET | gcloud kms encrypt --plaintext-file=- --ciphertext-file=- \
+# --location=global --keyring=[KEYRING-NAME] --key=[KEY-NAME] | base64
+
+# See below link for more information on using Google Cloud KMS:
+# https://cloud.google.com/container-builder/docs/securing-builds/use-encrypted-secrets-credentials#encrypting_an_environment_variable_using_the_cryptokey
+
+secrets:
+- kmsKeyName: 'projects/[GCP-PROJECT-ID]/locations/global/keyRings/[GCP-KMS-KEYRING-NAME]/cryptoKeys/[GCP-KMS-KEY-NAME]'
+  secretEnv:
+    SRCCLR_API_TOKEN:[ENCRYPTED-SOURCECLEAR-AGENT-API-TOKEN]
+    DOCKER_USERNAME: [ENCRYPTED-DOCKER-USERNAME]
+    DOCKER_PASSWORD: [ENCRYPTED-DOCKER-PASSWORD]
+
+# Build Steps:
+steps:
+
+#
+# Steps for building and testing vertx-template with Oracle DB
+#
+
+# Copying ojdbc7 dependency in GCB workspace
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp', 'gs://[GCS-BUCKET-HOSTING-OJDBC7.JAR]/ojdbc7.jar', 'ojdbc7.jar']
+
+# Copying sample.properties and pom.xml
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "cp ./oracle_sample.properties ./sample.properties; cp ./oracle_pom.xml ./pom.xml"]
+
+# Authenticating to Docker Store
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker login --username=$$DOCKER_USERNAME --password=$$DOCKER_PASSWORD']
+  secretEnv: ['DOCKER_USERNAME', 'DOCKER_PASSWORD']
+
+# Creating a separate network
+# It is required for communication between Oracle DB server and APP server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker network create $$ORACLEDB_NET']
+  env: ['ORACLEDB_NET=stanford-oracledb']
+
+# Creating an Oracle DB server 
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$ORACLEDB_SERVER --net $$ORACLEDB_NET \
+         -v /workspace:/workspace $$ORACLEDB_IMAGE"]
+  env: ['ORACLEDB_IMAGE=store/oracle/database-enterprise:12.2.0.1-slim', 'ORACLEDB_SERVER=oracle-dbserver',
+        'ORACLEDB_NET=stanford-oracledb']
+ 
+ # Checking the health of Oracle DB server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', './check_oracledb_health.sh']
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'ORACLEDB_SERVER=oracle-dbserver']
+
+# Building application jar using APP build server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run --name $$APP_BUILD_SERVER --net $$ORACLEDB_NET -e SRCCLR_API_TOKEN \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_BUILD_IMAGE \
+         -c 'apt-get update; apt-get install curl -y; cd /workspace; \
+         mvn install:install-file -Dfile=./ojdbc7.jar -DgroupId=com.oracle.jdbc -DartifactId=ojdbc7 \
+         -Dversion=12.1.0.2 -Dpackaging=jar; mvn -DskipTests clean package; \
+         curl -sSL https://download.sourceclear.com/ci.sh | sh'"]
+  env: ['APP_BUILD_SERVER=oracledb-app-build-server', 'ORACLEDB_NET=stanford-oracledb',
+        'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
+  secretEnv: ['SRCCLR_API_TOKEN']
+
+# Testing application jar using APP test server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$APP_TEST_SERVER --net $$ORACLEDB_NET \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_TEST_IMAGE -c 'cd /workspace; \
+         java -Djava.security.egd=file:/dev/./urandom -jar /workspace/target/vertx-*-SNAPSHOT.jar create-database run'"]
+  env: ['APP_TEST_SERVER=oracledb-app-test-server', 'ORACLEDB_NET=stanford-oracledb',
+        'APP_TEST_IMAGE=gcr.io/cloud-builders/mvn']
+
+# Checking database table created by application jar
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e ORACLEDB_SERVER -e DB_TBL_CHK_MAX_RETRY \
+         -e DB_TBL_CHK_SLEEP $$ORACLEDB_SERVER bash -c '/workspace/check_oracledb_table.sh'"]
+  env: ['DB_TBL_CHK_MAX_RETRY=10', 'DB_TBL_CHK_SLEEP=10', 'ORACLEDB_SERVER=oracle-dbserver']
+
+# Building GCR image for application jar
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/vertx-template-oracledb:latest', '-f', 'Dockerfile_oracledb', '.']
+
+#
+# Steps for building and testing vertx-template with Postgres
+#
+
+# Creating a separate network
+# It is required for communication between Postgres server and APP server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker network create $$POSTGRES_NET']
+  env: ['POSTGRES_NET=stanford-postgres']
+
+# Copying sample.properties and pom.xml
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "cp ./postgres_sample.properties ./sample.properties; cp ./postgres_pom.xml pom.xml"]
+
+# Creating a Postgres server 
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$POSTGRES_SERVER --net $$POSTGRES_NET \
+         -e POSTGRES_USER -e POSTGRES_PASSWORD -e POSTGRES_DB \
+         -v /workspace:/workspace $$POSTGRES_IMAGE"]
+  env: ['POSTGRES_IMAGE=postgres:9.3', 'POSTGRES_USER=test', 'POSTGRES_PASSWORD=test', 'POSTGRES_DB=test',
+        'POSTGRES_SERVER=postgres-dbserver', 'POSTGRES_NET=stanford-postgres']
+
+# Checking the health of Postgres server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_HLTH_CHK_MAX_RETRY \
+         -e DB_HLTH_CHK_SLEEP $$POSTGRES_SERVER /workspace/check_postgres_health.sh"]
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'POSTGRES_SERVER=postgres-dbserver']
+
+# Building application jar using APP build server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run --name $$APP_BUILD_SERVER --net $$POSTGRES_NET -e SRCCLR_API_TOKEN \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_BUILD_IMAGE \
+         -c 'apt-get update; apt-get install curl -y; cd /workspace; mvn -DskipTests -Ppostgres clean package; \
+         curl -sSL https://download.sourceclear.com/ci.sh | sh'"]
+  env: ['APP_BUILD_SERVER=postgres-app-build-server', 'POSTGRES_NET=stanford-postgres',
+        'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
+  secretEnv: ['SRCCLR_API_TOKEN']
+
+# Testing application jar using APP test server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$APP_TEST_SERVER --net $$POSTGRES_NET \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_TEST_IMAGE \
+         -c 'cd /workspace; java -jar /workspace/target/vertx-*-SNAPSHOT.jar create-database run'"]
+  env: ['APP_TEST_SERVER=postgres-app-test-server', 'POSTGRES_NET=stanford-postgres',
+        'APP_TEST_IMAGE=gcr.io/cloud-builders/mvn']
+
+# Checking database table created by application jar
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_TBL_CHK_MAX_RETRY \
+         -e DB_TBL_CHK_SLEEP $$POSTGRES_SERVER bash -c '/workspace/check_postgres_table.sh'"]
+  env: ['DB_TBL_CHK_MAX_RETRY=10', 'DB_TBL_CHK_SLEEP=10', 'POSTGRES_SERVER=postgres-dbserver']
+
+# Building GCR image for application jar
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/vertx-template-postgres:latest', '-f', 'Dockerfile_postgres', '.']
+
+#
+# Uploading GCR images for application jar
+#
+images:
+  - 'gcr.io/$PROJECT_ID/vertx-template-postgres:latest'
+  - 'gcr.io/$PROJECT_ID/vertx-template-oracledb:latest'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,11 +13,11 @@
 # https://cloud.google.com/container-builder/docs/securing-builds/use-encrypted-secrets-credentials#encrypting_an_environment_variable_using_the_cryptokey
 
 secrets:
-- kmsKeyName: 'projects/[GCP-PROJECT-ID]/locations/global/keyRings/[GCP-KMS-KEYRING-NAME]/cryptoKeys/[GCP-KMS-KEY-NAME]'
+- kmsKeyName: 'projects/som-rit-infrastructure-dev/locations/global/keyRings/susom-encryption-keyring/cryptoKeys/susom-encryption-key'
   secretEnv:
-    SRCCLR_API_TOKEN:[ENCRYPTED-SOURCECLEAR-AGENT-API-TOKEN]
-    DOCKER_USERNAME: [ENCRYPTED-DOCKER-USERNAME]
-    DOCKER_PASSWORD: [ENCRYPTED-DOCKER-PASSWORD]
+    SRCCLR_API_TOKEN: CiQAZ2BXpn/Kh1BhBPJTo04sTqH7HvWveMKq7XWanLFLLlBqdlwSxgMA+/0rWrQhkX0mwX+/XXqIGA7ltoW3+8hGID8fCpX3RPHzWzKtepUSyYoB0aDnTox7D3HFx4jZxl5XwpBznP4dxuovhSiwwT+HPRAvoxDMivrPYltPXmDkSE6VTCo2weFw9mQeyi6VIaha/lzDVQIsmZDIMbq8l3fLA6GxcJKjK137DOuNW1pnCg7sEJq7IKR7j4iMyKLDvplJUBb6vIXGMBunj8gNUXLsC0uunol2XmRrDSHlQAGxmz608CUiqygieygLW5/SIV4ApM6XweN74XzmpsZk+DW1HmRxvx/J1q0aVCYML/tanyxI/KpqhOisoEPfJLnRsJaEDORQqLC3Sb9ZTUSj0PVF1CHV6SjggEcB/UyGAqmAE5Hd4wvj2GhE0EjPApaUPHU5KrvTv6xWOOfSTUO5z5jZdebPHxDvP4UMgWyhIFgRwqptdAGC3hVy02fLxarQABFAKBL23+UZZKDloE13qmcNtak9EqfG7HbJbfi8NhOSSl5w/f6U+VPiLjkFHrn8Sjst9L/nhlFn2E6OqoOYiHdJTW4uG9U7QBVHZw1n9xSuB9SiHZYYB2ttXX3TcthyzKddxs0w03AwXS04rwaL
+    DOCKER_USERNAME: CiQAZ2BXpv1Ooms6nocrIRlv3ikIAvvQ3Cu1kLR+0c/re88rOTsSMgD7/StaAzqTQq1IeXEQwBifL0au7PVZcnsOwNUKGIDUyb33eeiySHEebmiRL/jQ+Lhd
+    DOCKER_PASSWORD: CiQAZ2BXprYOJAqrlJaAO9oGJHhrz6MiuN8J4se4Ne4CADhtkVoSNAD7/StaXPEWv9XQ80ID4QTyTyo5ApD3uOAsUb9bhc0irKIwHJq7eVlo9dc5DmlBgC1DED8=
 
 # Build Steps:
 steps:
@@ -28,7 +28,7 @@ steps:
 
 # Copying ojdbc7 dependency in GCB workspace
 - name: 'gcr.io/cloud-builders/gsutil'
-  args: ['cp', 'gs://[GCS-BUCKET-HOSTING-OJDBC7.JAR]/ojdbc7.jar', 'ojdbc7.jar']
+  args: ['cp', 'gs://susom-vertx-template-jdbc/ojdbc7.jar', 'ojdbc7.jar']
 
 # Copying sample.properties and pom.xml
 - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild_oracledb.yaml
+++ b/cloudbuild_oracledb.yaml
@@ -54,12 +54,6 @@ steps:
   env: ['ORACLEDB_IMAGE=store/oracle/database-enterprise:12.2.0.1-slim', 'ORACLEDB_SERVER=oracle-dbserver',
         'ORACLEDB_NET=stanford-oracledb']
 
-# Checking the health of Oracle DB server
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: ['-c', './check_oracledb_health.sh']
-  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'ORACLEDB_SERVER=oracle-dbserver']
-
 # Building application jar using APP build server
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
@@ -72,6 +66,12 @@ steps:
   env: ['APP_BUILD_SERVER=oracledb-app-build-server', 'ORACLEDB_NET=stanford-oracledb',
         'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
   secretEnv: ['SRCCLR_API_TOKEN']
+
+# Checking the health of Oracle DB server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', './check_oracledb_health.sh']
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'ORACLEDB_SERVER=oracle-dbserver']
 
 # Testing application jar using APP test server
 - name: 'gcr.io/cloud-builders/docker'

--- a/cloudbuild_oracledb.yaml
+++ b/cloudbuild_oracledb.yaml
@@ -1,0 +1,98 @@
+#
+# cloudbuild.yaml for building and testing vertx-template with Oracle DB in GCB
+#
+
+# Google Cloud KMS KeyRing and CryptoKey are created for encrypting credentials of SourceClear and Docker Store
+# Container Builder service account is granted access to the CryptoKey.
+# Run the following command in shell or terminal window to encrpt SourceClear and Docker Store credentials
+# MY_SECRET=<enter-your-credential>
+# echo -n $MY_SECRET | gcloud kms encrypt --plaintext-file=- --ciphertext-file=- \
+# --location=global --keyring=[KEYRING-NAME] --key=[KEY-NAME] | base64
+
+# See below link for more information on using Google Cloud KMS:
+# https://cloud.google.com/container-builder/docs/securing-builds/use-encrypted-secrets-credentials#encrypting_an_environment_variable_using_the_cryptokey
+
+secrets:
+- kmsKeyName: 'projects/[GCP-PROJECT-ID]/locations/global/keyRings/[GCP-KMS-KEYRING-NAME]/cryptoKeys/[GCP-KMS-KEY-NAME]'
+  secretEnv:
+    SRCCLR_API_TOKEN:[ENCRYPTED-SOURCECLEAR-AGENT-API-TOKEN]
+    DOCKER_USERNAME: [ENCRYPTED-DOCKER-USERNAME]
+    DOCKER_PASSWORD: [ENCRYPTED-DOCKER-PASSWORD]
+
+#
+# Steps for building and testing vertx-template with Oracle DB
+#
+
+# Copying ojdbc7 dependency in GCB workspace
+steps:
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp', 'gs://[GCS-BUCKET-HOSTING-OJDBC7.JAR]/ojdbc7.jar', 'ojdbc7.jar']
+
+# Copying sample.properties and pom.xml
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "cp ./oracle_sample.properties ./sample.properties; cp ./oracle_pom.xml ./pom.xml"]
+
+# Authenticating to Docker Store
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker login --username=$$DOCKER_USERNAME --password=$$DOCKER_PASSWORD']
+  secretEnv: ['DOCKER_USERNAME', 'DOCKER_PASSWORD']
+
+# Creating a separate network
+# It is required for communication between Oracle DB server and APP server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker network create $$ORACLEDB_NET']
+  env: ['ORACLEDB_NET=stanford-oracledb']
+
+# Creating an Oracle DB server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$ORACLEDB_SERVER --net $$ORACLEDB_NET \
+         -v /workspace:/workspace $$ORACLEDB_IMAGE"]
+  env: ['ORACLEDB_IMAGE=store/oracle/database-enterprise:12.2.0.1-slim', 'ORACLEDB_SERVER=oracle-dbserver',
+        'ORACLEDB_NET=stanford-oracledb']
+
+# Checking the health of Oracle DB server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', './check_oracledb_health.sh']
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'ORACLEDB_SERVER=oracle-dbserver']
+
+# Building application jar using APP build server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run --name $$APP_BUILD_SERVER --net $$ORACLEDB_NET -e SRCCLR_API_TOKEN \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_BUILD_IMAGE \
+         -c 'apt-get update; apt-get install curl -y; cd /workspace; \
+         mvn install:install-file -Dfile=./ojdbc7.jar -DgroupId=com.oracle.jdbc -DartifactId=ojdbc7 \
+         -Dversion=12.1.0.2 -Dpackaging=jar; mvn -DskipTests clean package; \
+         curl -sSL https://download.sourceclear.com/ci.sh | sh'"]
+  env: ['APP_BUILD_SERVER=oracledb-app-build-server', 'ORACLEDB_NET=stanford-oracledb',
+        'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
+  secretEnv: ['SRCCLR_API_TOKEN']
+
+# Testing application jar using APP test server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$APP_TEST_SERVER --net $$ORACLEDB_NET \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_TEST_IMAGE -c 'cd /workspace; \
+         java -Djava.security.egd=file:/dev/./urandom -jar /workspace/target/vertx-*-SNAPSHOT.jar create-database run'"]
+  env: ['APP_TEST_SERVER=oracledb-app-test-server', 'ORACLEDB_NET=stanford-oracledb',
+        'APP_TEST_IMAGE=gcr.io/cloud-builders/mvn']
+
+# Checking database table created by application jar
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e ORACLEDB_SERVER -e DB_TBL_CHK_MAX_RETRY \
+         -e DB_TBL_CHK_SLEEP $$ORACLEDB_SERVER bash -c '/workspace/check_oracledb_table.sh'"]
+  env: ['DB_TBL_CHK_MAX_RETRY=10', 'DB_TBL_CHK_SLEEP=10', 'ORACLEDB_SERVER=oracle-dbserver']
+
+# Building GCR image for application jar
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/vertx-template-oracledb:latest', '-f', 'Dockerfile_oracledb', '.']
+
+# Uploading GCR image for application jar
+images:
+  - 'gcr.io/$PROJECT_ID/vertx-template-oracledb:latest'

--- a/cloudbuild_postgres.yaml
+++ b/cloudbuild_postgres.yaml
@@ -1,0 +1,86 @@
+#
+# cloudbuild.yaml for building and testing vertx-template with Postgres in GCB
+#
+
+# Google Cloud KMS KeyRing and CryptoKey are created for encrypting credential of SourceClear
+# Container Builder service account is granted access to the CryptoKey.
+# Run the following command in shell or terminal window to encrpt SourceClear credential
+# MY_SECRET=<enter-your-credential>
+# echo -n $MY_SECRET | gcloud kms encrypt --plaintext-file=- --ciphertext-file=- \
+# --location=global --keyring=[KEYRING-NAME] --key=[KEY-NAME] | base64
+
+# See below link for more information on using Google Cloud KMS:
+# https://cloud.google.com/container-builder/docs/securing-builds/use-encrypted-secrets-credentials#encrypting_an_environment_variable_using_the_cryptokey
+
+secrets:
+- kmsKeyName: 'projects/[GCP-PROJECT-ID]/locations/global/keyRings/[GCP-KMS-KEYRING-NAME]/cryptoKeys/[GCP-KMS-KEY-NAME]'
+  secretEnv:
+    SRCCLR_API_TOKEN:[ENCRYPTED-SOURCECLEAR-AGENT-API-TOKEN]
+
+#
+# Steps for building and testing vertx-template with Postgres
+#
+steps:
+
+# Creating a separate network
+# It is required for communication between Postgres server and APP server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', 'docker network create $$POSTGRES_NET']
+  env: ['POSTGRES_NET=stanford-postgres']
+
+# Copying sample.properties and pom.xml
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "cp ./postgres_sample.properties ./sample.properties; cp ./postgres_pom.xml pom.xml"]
+
+# Creating a Postgres server 
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$POSTGRES_SERVER --net $$POSTGRES_NET \
+         -e POSTGRES_USER -e POSTGRES_PASSWORD -e POSTGRES_DB \
+         -v /workspace:/workspace $$POSTGRES_IMAGE"]
+  env: ['POSTGRES_IMAGE=postgres:9.3', 'POSTGRES_USER=test', 'POSTGRES_PASSWORD=test', 'POSTGRES_DB=test',
+        'POSTGRES_SERVER=postgres-dbserver', 'POSTGRES_NET=stanford-postgres']
+
+# Checking the health of Postgres server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_HLTH_CHK_MAX_RETRY \
+         -e DB_HLTH_CHK_SLEEP $$POSTGRES_SERVER /workspace/check_postgres_health.sh"]
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'POSTGRES_SERVER=postgres-dbserver']
+
+# Building application jar using APP build server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run --name $$APP_BUILD_SERVER --net $$POSTGRES_NET -e SRCCLR_API_TOKEN \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_BUILD_IMAGE \
+         -c 'apt-get update; apt-get install curl -y; cd /workspace; mvn -DskipTests -Ppostgres clean package; \
+         curl -sSL https://download.sourceclear.com/ci.sh | sh'"]
+  env: ['APP_BUILD_SERVER=postgres-app-build-server', 'POSTGRES_NET=stanford-postgres',
+        'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
+  secretEnv: ['SRCCLR_API_TOKEN']
+
+# Testing application jar using APP test server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker run -d --name $$APP_TEST_SERVER --net $$POSTGRES_NET \
+         -v /workspace:/workspace --entrypoint 'bash' $$APP_TEST_IMAGE \
+         -c 'cd /workspace; java -jar /workspace/target/vertx-*-SNAPSHOT.jar create-database run'"]
+  env: ['APP_TEST_SERVER=postgres-app-test-server', 'POSTGRES_NET=stanford-postgres',
+        'APP_TEST_IMAGE=gcr.io/cloud-builders/mvn']
+
+# Checking database table created by application jar
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_TBL_CHK_MAX_RETRY \
+         -e DB_TBL_CHK_SLEEP $$POSTGRES_SERVER bash -c '/workspace/check_postgres_table.sh'"]
+  env: ['DB_TBL_CHK_MAX_RETRY=10', 'DB_TBL_CHK_SLEEP=10', 'POSTGRES_SERVER=postgres-dbserver']
+
+# Building GCR image for application jar
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/$PROJECT_ID/vertx-template-postgres:latest', '-f', 'Dockerfile_postgres', '.']
+
+# Uploading GCR image for application jar
+images:
+  - 'gcr.io/$PROJECT_ID/vertx-template-postgres:latest'

--- a/cloudbuild_postgres.yaml
+++ b/cloudbuild_postgres.yaml
@@ -43,13 +43,6 @@ steps:
   env: ['POSTGRES_IMAGE=postgres:9.3', 'POSTGRES_USER=test', 'POSTGRES_PASSWORD=test', 'POSTGRES_DB=test',
         'POSTGRES_SERVER=postgres-dbserver', 'POSTGRES_NET=stanford-postgres']
 
-# Checking the health of Postgres server
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_HLTH_CHK_MAX_RETRY \
-         -e DB_HLTH_CHK_SLEEP $$POSTGRES_SERVER /workspace/check_postgres_health.sh"]
-  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'POSTGRES_SERVER=postgres-dbserver']
-
 # Building application jar using APP build server
 - name: 'gcr.io/cloud-builders/docker'
   entrypoint: 'bash'
@@ -60,6 +53,13 @@ steps:
   env: ['APP_BUILD_SERVER=postgres-app-build-server', 'POSTGRES_NET=stanford-postgres',
         'APP_BUILD_IMAGE=gcr.io/cloud-builders/mvn']
   secretEnv: ['SRCCLR_API_TOKEN']
+
+# Checking the health of Postgres server
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  args: ['-c', "docker exec -e POSTGRES_SERVER -e DB_HLTH_CHK_MAX_RETRY \
+         -e DB_HLTH_CHK_SLEEP $$POSTGRES_SERVER /workspace/check_postgres_health.sh"]
+  env: ['DB_HLTH_CHK_MAX_RETRY=7', 'DB_HLTH_CHK_SLEEP=20', 'POSTGRES_SERVER=postgres-dbserver']
 
 # Testing application jar using APP test server
 - name: 'gcr.io/cloud-builders/docker'

--- a/oracle_pom.xml
+++ b/oracle_pom.xml
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.susom</groupId>
+    <artifactId>vertx-parent</artifactId>
+    <version>1.1</version>
+  </parent>
+
+  <artifactId>vertx-template</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>Sample Vert.x application.</description>
+  <url>https://github.com/susom/vertx-template</url>
+
+  <properties>
+    <main.class>com.github.susom.app.server.container.Main</main.class>
+  </properties>
+
+  <dependencies>
+    <!-- Temporary override to pickup snapshots -->
+    <dependency>
+      <groupId>com.github.susom</groupId>
+      <artifactId>vertx-base</artifactId>
+      <version>1.1-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle.jdbc</groupId>
+      <artifactId>ojdbc7</artifactId>
+      <version>12.1.0.2</version>
+      <scope>runtime</scope>
+    </dependency>
+    <!-- There are three profiles ("hsql" the default, "postgres", and "oracle")
+         that are normally used to control which database drivers get embedded
+         in our executable jar. If you want to always include a particular set,
+         uncomment them here.
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>ojdbc7</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    -->
+
+    <!-- You get the latest JUnit and VertxUnit from the parent, but you
+         might want this one as well
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.8</version>
+      <scope>test</scope>
+    </dependency>
+    -->
+  </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Garrick Olson</name>
+      <email>garricko@stanford.edu</email>
+      <organization>Stanford Medicine</organization>
+      <organizationUrl>https://med.stanford.edu</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/susom/vertx-template.git</connection>
+    <developerConnection>scm:git:https://github.com/susom/vertx-template.git</developerConnection>
+    <url>https://github.com/susom/vertx-template</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>packagecloud</id>
+      <url>https://packagecloud.io/garricko/travis/maven2</url>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>packagecloud</id>
+      <url>https://packagecloud.io/garricko/travis/maven2</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Unpack files from parent pom so later plugins can use them
+             (some plugins require actual files for config rather than
+             using resources) -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <configuration>
+          <outputDirectory>target/parent-files</outputDirectory>
+          <artifactItems>
+            <artifactItem>
+              <groupId>${project.parent.groupId}</groupId>
+              <artifactId>vertx-parent-file</artifactId>
+              <version>${project.parent.version}</version>
+            </artifactItem>
+          </artifactItems>
+          <includeArtifactIds>vertx-parent-files</includeArtifactIds>
+        </configuration>
+        <executions>
+          <execution>
+            <id>unpack-parent-files</id>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <phase>generate-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Run unit tests matching **/*(^(Db|Oracle|Hsql|Postgres))Test-->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <!-- Run database/system tests matching **/*(Db|Oracle|Hsql|Postgres)Test-->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <!-- Create the combined executable jar -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <!-- There are a number of profiles you get for free from the parent. For
+         database drivers and database specific integration tests:
+
+         -P hsql (default if no other profile is active)
+         -P postgres
+         -P oracle
+
+         Some code analysis tools are mutually incompatible, so those profiles
+         are grouped into two sets, enabled by system properties:
+
+         -Dcheck1 (a.k.a. -Pcheck-errorprone,check-macker,check-forbidden,checkstyle)
+         -Dcheck2 (a.k.a. -Pchecker)
+         -->
+    <profile>
+      <id>packagecloud</id>
+      <repositories>
+        <repository>
+          <id>packagecloud</id>
+          <url>https://packagecloud.io/garricko/travis/maven2</url>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- Create deploy.zip with app and docker artifacts-->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/oracle_sample.properties
+++ b/oracle_sample.properties
@@ -1,0 +1,51 @@
+# By default we will use a local, embedded Java database for
+# convenience during development
+#database.url=jdbc:hsqldb:file:.hsql/db;shutdown=true
+#database.user=SA
+#database.password=
+database.driver=oracle.jdbc.driver.OracleDriver
+database.url=jdbc:oracle:thin:@oracle-dbserver:1521/ORCLCDB.localdomain
+database.user=sys as sysdba
+database.password=Oradoc_db1
+
+# Declare any outbound network connections to be allowed by security manager
+#connect.outbound=some-database:1521,my-email-server:1234
+connect.outbound=oracle-dbserver:1521
+
+# Enable development features to make life easier, such as
+# fake authentication
+insecure.fake.security=yes
+insecure.dev.mode=yes
+
+# Customize the port and network interface on which to listen
+# Use host 0.0.0.0 if you want to be able to connect remotely
+listen.url=http://localhost:8000
+
+# External (proxy/LB) location for this app
+public.url=http://localhost:8000
+
+# Web application context (in http://example.com/foo/bar/?baz
+# it is the "foo" portion)
+app.context=secure-app
+
+# If serving https we need the private key
+#ssl.keystore.path=local.ssl.jks
+#ssl.keystore.password=secret
+
+# OpenID Connect client info
+auth.client.id=secure-app
+auth.client.secret=...
+auth.client.base.uri=http://localhost:8000/secure-app
+
+# OpenID Connect server info
+auth.server.base.uri=http://localhost:8080/auth/realms/demo/protocol/openid-connect
+auth.server.public.key=...
+
+# Disable database health check to make logs easier to read
+healthcheck.interval.seconds=-1
+
+# For debugging, if you want to see everything in the HTTP requests
+#insecure.log.full.requests=yes
+
+# Uncomment to disable compression (enabled by default)
+#http.compression=no

--- a/postgres_pom.xml
+++ b/postgres_pom.xml
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.github.susom</groupId>
+    <artifactId>vertx-parent</artifactId>
+    <version>1.1</version>
+  </parent>
+
+  <artifactId>vertx-template</artifactId>
+  <packaging>jar</packaging>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>${project.groupId}:${project.artifactId}</name>
+  <description>Sample Vert.x application.</description>
+  <url>https://github.com/susom/vertx-template</url>
+
+  <properties>
+    <main.class>com.github.susom.app.server.container.Main</main.class>
+  </properties>
+
+  <dependencies>
+    <!-- Temporary override to pickup snapshots -->
+    <dependency>
+      <groupId>com.github.susom</groupId>
+      <artifactId>vertx-base</artifactId>
+      <version>1.1-SNAPSHOT</version>
+    </dependency>
+    <!-- There are three profiles ("hsql" the default, "postgres", and "oracle")
+         that are normally used to control which database drivers get embedded
+         in our executable jar. If you want to always include a particular set,
+         uncomment them here.
+    <dependency>
+      <groupId>org.hsqldb</groupId>
+      <artifactId>hsqldb</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.oracle</groupId>
+      <artifactId>ojdbc7</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    -->
+
+    <!-- You get the latest JUnit and VertxUnit from the parent, but you
+         might want this one as well
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.8</version>
+      <scope>test</scope>
+    </dependency>
+    -->
+  </dependencies>
+
+  <licenses>
+    <license>
+      <name>The Apache Software License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
+
+  <developers>
+    <developer>
+      <name>Garrick Olson</name>
+      <email>garricko@stanford.edu</email>
+      <organization>Stanford Medicine</organization>
+      <organizationUrl>https://med.stanford.edu</organizationUrl>
+    </developer>
+  </developers>
+
+  <scm>
+    <connection>scm:git:https://github.com/susom/vertx-template.git</connection>
+    <developerConnection>scm:git:https://github.com/susom/vertx-template.git</developerConnection>
+    <url>https://github.com/susom/vertx-template</url>
+    <tag>HEAD</tag>
+  </scm>
+
+  <repositories>
+    <repository>
+      <id>packagecloud</id>
+      <url>https://packagecloud.io/garricko/travis/maven2</url>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+    </repository>
+    <repository>
+      <id>central</id>
+      <url>https://repo.maven.apache.org/maven2/</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+    </repository>
+  </repositories>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>packagecloud</id>
+      <url>https://packagecloud.io/garricko/travis/maven2</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!-- Unpack files from parent pom so later plugins can use them
+             (some plugins require actual files for config rather than
+             using resources) -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <configuration>
+          <outputDirectory>target/parent-files</outputDirectory>
+          <artifactItems>
+            <artifactItem>
+              <groupId>${project.parent.groupId}</groupId>
+              <artifactId>vertx-parent-file</artifactId>
+              <version>${project.parent.version}</version>
+            </artifactItem>
+          </artifactItems>
+          <includeArtifactIds>vertx-parent-files</includeArtifactIds>
+        </configuration>
+        <executions>
+          <execution>
+            <id>unpack-parent-files</id>
+            <goals>
+              <goal>unpack-dependencies</goal>
+            </goals>
+            <phase>generate-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <!-- Run unit tests matching **/*(^(Db|Oracle|Hsql|Postgres))Test-->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <!-- Run database/system tests matching **/*(Db|Oracle|Hsql|Postgres)Test-->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <!-- Create the combined executable jar -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <profiles>
+    <!-- There are a number of profiles you get for free from the parent. For
+         database drivers and database specific integration tests:
+
+         -P hsql (default if no other profile is active)
+         -P postgres
+         -P oracle
+
+         Some code analysis tools are mutually incompatible, so those profiles
+         are grouped into two sets, enabled by system properties:
+
+         -Dcheck1 (a.k.a. -Pcheck-errorprone,check-macker,check-forbidden,checkstyle)
+         -Dcheck2 (a.k.a. -Pchecker)
+         -->
+    <profile>
+      <id>packagecloud</id>
+      <repositories>
+        <repository>
+          <id>packagecloud</id>
+          <url>https://packagecloud.io/garricko/travis/maven2</url>
+          <snapshots>
+            <enabled>true</enabled>
+            <updatePolicy>always</updatePolicy>
+          </snapshots>
+        </repository>
+      </repositories>
+    </profile>
+
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <!-- Create deploy.zip with app and docker artifacts-->
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-assembly-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>release-sign-artifacts</id>
+      <activation>
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/postgres_sample.properties
+++ b/postgres_sample.properties
@@ -1,0 +1,49 @@
+# By default we will use a local, embedded Java database for
+# convenience during development
+#database.url=jdbc:hsqldb:file:.hsql/db;shutdown=true
+#database.user=SA
+#database.password=
+database.url=jdbc:postgresql://postgres-dbserver:5432/test
+database.user=test
+database.password=test
+# Declare any outbound network connections to be allowed by security manager
+#connect.outbound=some-database:1521,my-email-server:1234
+connect.outbound=postgres-dbserver:5432
+
+# Enable development features to make life easier, such as
+# fake authentication
+insecure.fake.security=yes
+insecure.dev.mode=yes
+
+# Customize the port and network interface on which to listen
+# Use host 0.0.0.0 if you want to be able to connect remotely
+listen.url=http://localhost:8000
+
+# External (proxy/LB) location for this app
+public.url=http://localhost:8000
+
+# Web application context (in http://example.com/foo/bar/?baz
+# it is the "foo" portion)
+app.context=secure-app
+
+# If serving https we need the private key
+#ssl.keystore.path=local.ssl.jks
+#ssl.keystore.password=secret
+
+# OpenID Connect client info
+auth.client.id=secure-app
+auth.client.secret=...
+auth.client.base.uri=http://localhost:8000/secure-app
+
+# OpenID Connect server info
+auth.server.base.uri=http://localhost:8080/auth/realms/demo/protocol/openid-connect
+auth.server.public.key=...
+
+# Disable database health check to make logs easier to read
+healthcheck.interval.seconds=-1
+
+# For debugging, if you want to see everything in the HTTP requests
+#insecure.log.full.requests=yes
+
+# Uncomment to disable compression (enabled by default)
+#http.compression=no


### PR DESCRIPTION
This PR translate .travis.yml to cloudbuild.yaml with postgres and OracleDB support.
We have created consolidated as well as separate cloudbuild.yaml for postgres and OracleDB.
We created separate pom.xml and sample.properties for postgres and OracleDB
We created separate Dockerfile for postgres and OracleDB

Example build log is attached to this PR description.
[build-log.txt](https://github.com/susom/vertx-template/files/2069977/build-log.txt)
